### PR TITLE
feat: support and test compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,13 @@ jobs:
     strategy:
       matrix:
         node: [16, 18, 19]
+        compression: [true, false]
     name: Test on Node ${{ matrix.node }}
     runs-on: macos-latest
     env:
       MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       CACHE_NAME: js-io-redis-client-test-ci
+      COMPRESSION: ${{ matrix.compression }}
 
     steps:
       - name: Setup repo

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/sdk": "^1.74.0",
+        "@gomomento/sdk": "^1.75.0",
         "ioredis": "^5.3.2"
       },
       "devDependencies": {
+        "@gomomento/sdk-nodejs-compression": "^0.75.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^18.15.11",
         "@types/uuid": "^9.0.1",
@@ -734,12 +735,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.74.0.tgz",
-      "integrity": "sha512-3iySeVe0lL/QBAUHRV08rZleqE8TGns710eh+vIMGomG1ZwX0gEaRY5jLfLSnGK/W8Sept5JT543FQ15sbbaPA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.75.0.tgz",
+      "integrity": "sha512-WnJr0CWhaFV8OhMH6sE1PxrOnbWIO63a0VOvZBm2IrpfcIc8RgKZbYCL+DRMVVsDbe4Q9C9xPINGI6ElZFenlQ==",
       "dependencies": {
         "@gomomento/generated-types": "0.108.2",
-        "@gomomento/sdk-core": "1.74.0",
+        "@gomomento/sdk-core": "1.75.0",
         "@grpc/grpc-js": "1.10.5",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -750,15 +751,54 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.74.0.tgz",
-      "integrity": "sha512-fIsNkWw7wIyDFbOPFFAB2mVnKClNWJMQd3O0t58PAZF9XcvohU2OLTvrcVr8E7fjpsaGVNn5Q8aroQ+lnrJCOA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.75.0.tgz",
+      "integrity": "sha512-3BY0SEcRdJY0u0cj3jEtK/wTDjC2Cl4JHWAGKQaYtbSoYCadOy/EScs9ZMytceTOA90lewAV+Vw+FU6zOeKXcw==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@gomomento/sdk-nodejs-compression": {
+      "version": "0.75.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-nodejs-compression/-/sdk-nodejs-compression-0.75.0.tgz",
+      "integrity": "sha512-XUQvXjs+NGOV/ACRVPcpGSJh7J9HT/YmCaBXHl+Mu6F3IIsSRiqYCt/NebrxC2f5pUXeBXdzmWUxKEAX/ZWhrw==",
+      "dev": true,
+      "dependencies": {
+        "@gomomento/generated-types": "0.107.4",
+        "@gomomento/sdk": "1.75.0",
+        "@mongodb-js/zstd": "1.2.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@gomomento/generated-types": {
+      "version": "0.107.4",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.107.4.tgz",
+      "integrity": "sha512-cvtm0IItHHNh2sthjQONxOqkCPP1FB+hYHc65k7O6BsHecyF0/V2qp8UU0tEQoE84kyf1LwK67TRoIZyuGZSpw==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/grpc-js": "1.10.0",
+        "google-protobuf": "3.21.2",
+        "grpc-tools": "^1.12.4",
+        "protoc-gen-ts": "^0.8.6"
+      }
+    },
+    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@grpc/grpc-js": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.0.tgz",
+      "integrity": "sha512-tx+eoEsqkMkLCHR4OOplwNIaJ7SVZWzeVKzEMBz8VR+TbssgBYOP4a0P+KQiQ6LaTG4SGaIEu7YTS8xOmkOWLA==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -1201,6 +1241,136 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mongodb-js/zstd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-1.2.0.tgz",
+      "integrity": "sha512-sKHsJU2MXsp822IFXOHw/4mpFulScNHpZzVy1Zi5k5wBsdiAPx1QramyOXZkpacla+2QPEC/s7TxPlEhG/HuNQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/zstd-darwin-arm64": "1.2.0",
+        "@mongodb-js/zstd-darwin-x64": "1.2.0",
+        "@mongodb-js/zstd-linux-arm64-gnu": "1.2.0",
+        "@mongodb-js/zstd-linux-arm64-musl": "1.2.0",
+        "@mongodb-js/zstd-linux-x64-gnu": "1.2.0",
+        "@mongodb-js/zstd-linux-x64-musl": "1.2.0",
+        "@mongodb-js/zstd-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-arm64/-/zstd-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-QWgW6IkWp3ErBXOvlOj9lw3lwMfey7eXh/p/Srb/7sEiu1e0yEO+LQ8IctmDWh8bfznKXmwUC0h7LKDbYR30yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-x64/-/zstd-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-VnxYO8P2SWubdnydGId5+6veO6Ki6nxCr/pTaDZd8s4Urn6bDdXSX6YsZ0r42dO3Fa0FVYzrlcVAuNB67e2b6w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-gnu/-/zstd-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-TYF0XgNJW6UrvtY2u4Uuo5HiVWNgWNZ/ae2BhVp8hNsDhwFqb/YNoyiZqBei6whUwr8hecMy0UaHAXm3h+O2+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-musl/-/zstd-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-e2ClmJI1BvJq23VSLH14hgjjjcMOad3R/Ap7Q7dTa1uiVSJG4xKd2CmrWQgX1Az4/EfUMWEI7pb4yuanbdd2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-gnu/-/zstd-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-JuoK8lxUlkFPDBfsBUJKnLxpXA5ar+v7G43lIUlBKgjOp5aEWO/qQp5sNgCRnYA7x6PItYqIkEJjsays4N6JOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-musl/-/zstd-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-pSb1iUF3Gc/qrJuP/Mi5ry4YFAUdUVFKNRZh1KTDDhSWyRCLd9gKcNdRnXqJjIdeGGEKf4bhtZAbYw4i/g0foA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mongodb-js/zstd-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-win32-x64-msvc/-/zstd-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-iz4Yl+WK3yr/4Yg6F4tKz3X9+yMZDK6pyBMA0CdXydSDZs6o2XQ2I0ZSu3oSk/ACfaZX3SNfRi3XTGgAM1eKZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@gomomento/sdk": "^1.74.0",
+    "@gomomento/sdk": "^1.75.0",
     "ioredis": "^5.3.2"
   },
   "devDependencies": {
+    "@gomomento/sdk-nodejs-compression": "^0.75.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
     "@types/uuid": "^9.0.1",

--- a/test/integration-setup.ts
+++ b/test/integration-setup.ts
@@ -7,12 +7,19 @@ import {
   MomentoErrorCode,
   CacheClient,
   CredentialProvider,
+  CacheConfiguration,
+  Configuration,
 } from '@gomomento/sdk';
+import {CompressorFactory} from '@gomomento/sdk-nodejs-compression';
 import {MomentoIORedis, MomentoRedisAdapter, NewIORedisWrapper} from '../src';
 
 export function testCacheName(): string {
   const name = process.env.CACHE_NAME || 'js-integration-test-default';
   return name + v4();
+}
+
+function useCompression(): boolean {
+  return process.env.COMPRESSION === 'true';
 }
 
 const deleteCacheIfExists = async (momento: CacheClient, cacheName: string) => {
@@ -25,8 +32,15 @@ const deleteCacheIfExists = async (momento: CacheClient, cacheName: string) => {
 };
 
 function momentoClientForTesting() {
+  let configuration: CacheConfiguration | Configuration =
+    Configurations.Laptop.latest();
+  if (useCompression()) {
+    configuration = configuration.withCompressionStrategy({
+      compressorFactory: CompressorFactory.default(),
+    });
+  }
   const IntegrationTestCacheClientProps: CacheClientProps = {
-    configuration: Configurations.Laptop.latest(),
+    configuration,
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
     }),


### PR DESCRIPTION
Supports compression via `@gomomento/sdk-nodejs-compression`, hooks up for `get` and `set` (except `setIfNotExists` for now), and adds compression to the test matrix.