### PR TITLE
feat: add ttl and pttl apis

### DIFF
--- a/src/momento-redis-adapter.ts
+++ b/src/momento-redis-adapter.ts
@@ -3,6 +3,7 @@ import {
   CacheClient,
   CacheDelete,
   CacheGet,
+  CacheItemGetTtl,
   CacheSet,
   CacheSetIfAbsent,
   MomentoErrorCode,
@@ -79,6 +80,10 @@ export interface MomentoIORedis {
     unixTimeMilliseconds: number | string,
     nx: 'NX'
   ): Promise<'OK' | null>;
+
+  ttl(key: RedisKey): Promise<number | null>;
+
+  pttl(key: RedisKey): Promise<number | null>;
 
   del(...args: [...keys: RedisKey[]]): Promise<number>;
 
@@ -294,6 +299,34 @@ export class MomentoRedisAdapter
       }
     }
 
+    return null;
+  }
+
+  async ttl(key: RedisKey): Promise<number | null> {
+    const rsp = await this.momentoClient.itemGetTtl(this.cacheName, key);
+    if (rsp instanceof CacheItemGetTtl.Hit) {
+      return rsp.remainingTtlMillis() / 1000;
+    } else if (rsp instanceof CacheItemGetTtl.Miss) {
+      return null;
+    } else if (rsp instanceof CacheItemGetTtl.Error) {
+      this.emitError('ttl', rsp.message(), rsp.errorCode());
+    } else {
+      this.emitError('ttl', 'unexpected-response');
+    }
+    return null;
+  }
+
+  async pttl(key: RedisKey): Promise<number | null> {
+    const rsp = await this.momentoClient.itemGetTtl(this.cacheName, key);
+    if (rsp instanceof CacheItemGetTtl.Hit) {
+      return rsp.remainingTtlMillis();
+    } else if (rsp instanceof CacheItemGetTtl.Miss) {
+      return null;
+    } else if (rsp instanceof CacheItemGetTtl.Error) {
+      this.emitError('ttl', rsp.message(), rsp.errorCode());
+    } else {
+      this.emitError('ttl', 'unexpected-response');
+    }
     return null;
   }
 }

--- a/test/get-set-delete.test.ts
+++ b/test/get-set-delete.test.ts
@@ -6,24 +6,27 @@ const {client} = SetupIntegrationTest();
 
 describe('simple get and set', () => {
   it('happy path set get update delete', async () => {
+    const key = v4();
+    const value1 = v4();
+    const value2 = v4();
     // Set initial key value
-    await client.set('mykey', 'value1');
+    await client.set(key, value1);
 
     // Get value
-    let result = await client.get('mykey');
-    expect(result).toEqual('value1');
+    let result = await client.get(key);
+    expect(result).toEqual(value1);
 
     // Update value
-    await client.set('mykey', 'value2');
+    await client.set(key, value2);
 
     // Read updated value
-    result = await client.get('mykey');
-    expect(result).toEqual('value2');
+    result = await client.get(key);
+    expect(result).toEqual(value2);
     // Delete key
-    await client.del('mykey');
+    await client.del(key);
 
     // Should get null back now
-    result = await client.get('mykey');
+    result = await client.get(key);
     expect(result).toBeNull();
   });
   it('should be null on a cache miss', async () => {

--- a/test/ttl.test.ts
+++ b/test/ttl.test.ts
@@ -1,0 +1,30 @@
+import {SetupIntegrationTest} from './integration-setup';
+import {v4} from 'uuid';
+
+const {client} = SetupIntegrationTest();
+
+describe('ttl', () => {
+  it('happy path ttl', async () => {
+    const key = v4();
+    const value = v4();
+
+    // Set initial key value with a 3 seconds expiration
+    await client.set(key, value, 'EX', 3);
+
+    // Get ttl of key
+    const ttlResp = await client.ttl(key);
+    expect(ttlResp).toBeGreaterThan(2);
+  });
+
+  it('happy path pttl', async () => {
+    const key = v4();
+    const value = v4();
+
+    // Set initial key value with a 3000 milliseconds expiration
+    await client.set(key, value, 'EX', 3);
+
+    // Get ttl of key
+    const pttlResp = await client.pttl(key);
+    expect(pttlResp).toBeGreaterThan(2000);
+  });
+});


### PR DESCRIPTION
## PR Description:
- Add ttl and pttl APIs

## Testing
- Momento: Integration tests ran using `npm run test-momento`
- Redis: Used the following docker-compose file to run a docker container:

```
version: '3'

services:
  redis:
    image: redis
    ports:
      - "6379:6379" # Expose Redis port
```
and then `docker compose up` to run the container. Ran the integration tests using `npm run test-redis`