### PR TITLE
fix: syntax for importing `EventEmitter`

### DIFF
--- a/src/momento-redis-adapter.ts
+++ b/src/momento-redis-adapter.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'stream';
+import {EventEmitter} from 'stream';
 import {
   CacheClient,
   CacheDelete,


### PR DESCRIPTION
When I was trying to consume our library from a toy npm project
where I had eslint rules set up the way we normally do in our
TS projects, I got an error because of this line where were
importing `EventEmitter` from 'stream':

```
node_modules/@gomomento-poc/node-ioredis-client/dist/src/momento-redis-adapter.d.ts:3:8 - error TS1259: Module '"stream"' can only be default-imported using the 'esModuleInterop' flag

3 import EventEmitter from 'stream';
         ~~~~~~~~~~~~

  node_modules/@types/node/stream.d.ts:1244:5
    1244     export = internal;
             ~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```

This commit changes the import syntax so that it doesn't look like
a "default import" anymore, to hopefully make us compatible with
a wider range of module systems.
