### PR TITLE
feat: re-export relevant types from Momento SDK to reduce required dependencies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,5 @@ export {
   NewIORedisWrapper,
   NewIORedisClusterWrapper,
 };
+
+export {CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';


### PR DESCRIPTION
Prior to this commit, if a user wants to use this library, they may need
to add the dependency on the library itself as well as on the Momento
SDK. This is because you need to construct instances of CredentialProvider,
Configuration, and CacheClient in order to call the constructor for the
Momento Redis adapter. If you are using eslint it will fail to build if you
try to import types from the Momento SDK as a transitive dependency, so you
have to declare it as an explicit dependency. This opens up a can of worms
for version conflicts between multiple installed versions of the Momento SDK.

This commit re-exports the relevant classes from the Momento SDK, so that they
can be imported directly from this library. That way users don't need to add
an additional dep on the Momento SDK.

In a subsequent commit we'll update the example code to leverage these new
imports.
