### PR TITLE
feat: remove dependency on momento compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     name: Test on Node ${{ matrix.node }}
     runs-on: macos-latest
     env:
-      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       CACHE_NAME: js-io-redis-client-test-ci
       COMPRESSION: ${{ matrix.compression }}
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const Redis = new MomentoRedisAdapter(
   new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
-      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+      environmentVariableName: 'MOMENTO_API_KEY',
     }),
     defaultTtlSeconds: 3600,
   }),
@@ -88,7 +88,7 @@ In this package we provide wrapper functions that help you configure wether or n
 | EnvVar Name         | Description                                                | Default |
 |---------------------|------------------------------------------------------------|---------|
 | MOMENTO_ENABLED     | Will allow you to toggle between using Momento and IORedis | false   |
-| MOMENTO_AUTH_TOKEN  | The Momento Auth token you would like to use               | ""      |
+| MOMENTO_API_KEY  | The Momento Auth token you would like to use               | ""      |
 | CACHE_NAME          | The name of the Momento Cache to use if Momento is enabled | ""      |
 | DEFAULT_TTL_SECONDS | The number of seconds to cache items for by default        | 86400   |
 

--- a/README.template.md
+++ b/README.template.md
@@ -55,7 +55,7 @@ const Redis = new MomentoRedisAdapter(
   new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
-      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+      environmentVariableName: 'MOMENTO_API_KEY',
     }),
     defaultTtlSeconds: 3600,
   }),
@@ -84,7 +84,7 @@ In this package we provide wrapper functions that help you configure wether or n
 | EnvVar Name         | Description                                                | Default |
 |---------------------|------------------------------------------------------------|---------|
 | MOMENTO_ENABLED     | Will allow you to toggle between using Momento and IORedis | false   |
-| MOMENTO_AUTH_TOKEN  | The Momento Auth token you would like to use               | ""      |
+| MOMENTO_API_KEY  | The Momento Auth token you would like to use               | ""      |
 | CACHE_NAME          | The name of the Momento Cache to use if Momento is enabled | ""      |
 | DEFAULT_TTL_SECONDS | The number of seconds to cache items for by default        | 86400   |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@gomomento/sdk": "^1.77.0",
+        "@mongodb-js/zstd": "^1.2.0",
         "ioredis": "5.3.2"
       },
       "devDependencies": {
-        "@gomomento/sdk-nodejs-compression": "^0.75.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^18.15.11",
         "@types/uuid": "^9.0.1",
@@ -32,6 +32,9 @@
         "ts-jest": "^29.0.5",
         "typescript": "5.0.4",
         "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -762,87 +765,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@gomomento/sdk-nodejs-compression": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-nodejs-compression/-/sdk-nodejs-compression-0.75.0.tgz",
-      "integrity": "sha512-XUQvXjs+NGOV/ACRVPcpGSJh7J9HT/YmCaBXHl+Mu6F3IIsSRiqYCt/NebrxC2f5pUXeBXdzmWUxKEAX/ZWhrw==",
-      "dev": true,
-      "dependencies": {
-        "@gomomento/generated-types": "0.107.4",
-        "@gomomento/sdk": "1.75.0",
-        "@mongodb-js/zstd": "1.2.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@gomomento/generated-types": {
-      "version": "0.107.4",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.107.4.tgz",
-      "integrity": "sha512-cvtm0IItHHNh2sthjQONxOqkCPP1FB+hYHc65k7O6BsHecyF0/V2qp8UU0tEQoE84kyf1LwK67TRoIZyuGZSpw==",
-      "dev": true,
-      "dependencies": {
-        "@grpc/grpc-js": "1.10.0",
-        "google-protobuf": "3.21.2",
-        "grpc-tools": "^1.12.4",
-        "protoc-gen-ts": "^0.8.6"
-      }
-    },
-    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@gomomento/generated-types/node_modules/@grpc/grpc-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.0.tgz",
-      "integrity": "sha512-tx+eoEsqkMkLCHR4OOplwNIaJ7SVZWzeVKzEMBz8VR+TbssgBYOP4a0P+KQiQ6LaTG4SGaIEu7YTS8xOmkOWLA==",
-      "dev": true,
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@gomomento/sdk": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.75.0.tgz",
-      "integrity": "sha512-WnJr0CWhaFV8OhMH6sE1PxrOnbWIO63a0VOvZBm2IrpfcIc8RgKZbYCL+DRMVVsDbe4Q9C9xPINGI6ElZFenlQ==",
-      "dev": true,
-      "dependencies": {
-        "@gomomento/generated-types": "0.108.2",
-        "@gomomento/sdk-core": "1.75.0",
-        "@grpc/grpc-js": "1.10.5",
-        "@types/google-protobuf": "3.15.10",
-        "google-protobuf": "3.21.2",
-        "jwt-decode": "3.1.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@gomomento/sdk-core": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.75.0.tgz",
-      "integrity": "sha512-3BY0SEcRdJY0u0cj3jEtK/wTDjC2Cl4JHWAGKQaYtbSoYCadOy/EScs9ZMytceTOA90lewAV+Vw+FU6zOeKXcw==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "6.0.3",
-        "jwt-decode": "3.1.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@gomomento/sdk-nodejs-compression/node_modules/@gomomento/sdk/node_modules/@gomomento/generated-types": {
-      "version": "0.108.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.108.2.tgz",
-      "integrity": "sha512-7cW0Orp8vGlSwWblNEHFHSVeXFJXgs9nJtYKB+CCx20mq86K/vGabXEdrZ9t3b7iw5+NVdJi5GRX13NombtRhw==",
-      "dev": true,
-      "dependencies": {
-        "@grpc/grpc-js": "1.10.5",
-        "google-protobuf": "3.21.2",
-        "grpc-tools": "^1.12.4",
-        "protoc-gen-ts": "^0.8.6"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.5.tgz",
@@ -1289,7 +1211,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-1.2.0.tgz",
       "integrity": "sha512-sKHsJU2MXsp822IFXOHw/4mpFulScNHpZzVy1Zi5k5wBsdiAPx1QramyOXZkpacla+2QPEC/s7TxPlEhG/HuNQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       },
@@ -1310,7 +1231,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1326,7 +1246,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1342,7 +1261,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1358,7 +1276,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1374,7 +1291,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1390,7 +1306,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1406,7 +1321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7741,81 +7655,6 @@
         "jwt-decode": "3.1.2"
       }
     },
-    "@gomomento/sdk-nodejs-compression": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-nodejs-compression/-/sdk-nodejs-compression-0.75.0.tgz",
-      "integrity": "sha512-XUQvXjs+NGOV/ACRVPcpGSJh7J9HT/YmCaBXHl+Mu6F3IIsSRiqYCt/NebrxC2f5pUXeBXdzmWUxKEAX/ZWhrw==",
-      "dev": true,
-      "requires": {
-        "@gomomento/generated-types": "0.107.4",
-        "@gomomento/sdk": "1.75.0",
-        "@mongodb-js/zstd": "1.2.0"
-      },
-      "dependencies": {
-        "@gomomento/generated-types": {
-          "version": "0.107.4",
-          "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.107.4.tgz",
-          "integrity": "sha512-cvtm0IItHHNh2sthjQONxOqkCPP1FB+hYHc65k7O6BsHecyF0/V2qp8UU0tEQoE84kyf1LwK67TRoIZyuGZSpw==",
-          "dev": true,
-          "requires": {
-            "@grpc/grpc-js": "1.10.0",
-            "google-protobuf": "3.21.2",
-            "grpc-tools": "^1.12.4",
-            "protoc-gen-ts": "^0.8.6"
-          },
-          "dependencies": {
-            "@grpc/grpc-js": {
-              "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.0.tgz",
-              "integrity": "sha512-tx+eoEsqkMkLCHR4OOplwNIaJ7SVZWzeVKzEMBz8VR+TbssgBYOP4a0P+KQiQ6LaTG4SGaIEu7YTS8xOmkOWLA==",
-              "dev": true,
-              "requires": {
-                "@grpc/proto-loader": "^0.7.8",
-                "@types/node": ">=12.12.47"
-              }
-            }
-          }
-        },
-        "@gomomento/sdk": {
-          "version": "1.75.0",
-          "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.75.0.tgz",
-          "integrity": "sha512-WnJr0CWhaFV8OhMH6sE1PxrOnbWIO63a0VOvZBm2IrpfcIc8RgKZbYCL+DRMVVsDbe4Q9C9xPINGI6ElZFenlQ==",
-          "dev": true,
-          "requires": {
-            "@gomomento/generated-types": "0.108.2",
-            "@gomomento/sdk-core": "1.75.0",
-            "@grpc/grpc-js": "1.10.5",
-            "@types/google-protobuf": "3.15.10",
-            "google-protobuf": "3.21.2",
-            "jwt-decode": "3.1.2"
-          },
-          "dependencies": {
-            "@gomomento/generated-types": {
-              "version": "0.108.2",
-              "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.108.2.tgz",
-              "integrity": "sha512-7cW0Orp8vGlSwWblNEHFHSVeXFJXgs9nJtYKB+CCx20mq86K/vGabXEdrZ9t3b7iw5+NVdJi5GRX13NombtRhw==",
-              "dev": true,
-              "requires": {
-                "@grpc/grpc-js": "1.10.5",
-                "google-protobuf": "3.21.2",
-                "grpc-tools": "^1.12.4",
-                "protoc-gen-ts": "^0.8.6"
-              }
-            }
-          }
-        },
-        "@gomomento/sdk-core": {
-          "version": "1.75.0",
-          "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.75.0.tgz",
-          "integrity": "sha512-3BY0SEcRdJY0u0cj3jEtK/wTDjC2Cl4JHWAGKQaYtbSoYCadOy/EScs9ZMytceTOA90lewAV+Vw+FU6zOeKXcw==",
-          "dev": true,
-          "requires": {
-            "buffer": "6.0.3",
-            "jwt-decode": "3.1.2"
-          }
-        }
-      }
-    },
     "@grpc/grpc-js": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.5.tgz",
@@ -8169,7 +8008,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-1.2.0.tgz",
       "integrity": "sha512-sKHsJU2MXsp822IFXOHw/4mpFulScNHpZzVy1Zi5k5wBsdiAPx1QramyOXZkpacla+2QPEC/s7TxPlEhG/HuNQ==",
-      "dev": true,
       "requires": {
         "@mongodb-js/zstd-darwin-arm64": "1.2.0",
         "@mongodb-js/zstd-darwin-x64": "1.2.0",
@@ -8184,49 +8022,42 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-arm64/-/zstd-darwin-arm64-1.2.0.tgz",
       "integrity": "sha512-QWgW6IkWp3ErBXOvlOj9lw3lwMfey7eXh/p/Srb/7sEiu1e0yEO+LQ8IctmDWh8bfznKXmwUC0h7LKDbYR30yw==",
-      "dev": true,
       "optional": true
     },
     "@mongodb-js/zstd-darwin-x64": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-darwin-x64/-/zstd-darwin-x64-1.2.0.tgz",
       "integrity": "sha512-VnxYO8P2SWubdnydGId5+6veO6Ki6nxCr/pTaDZd8s4Urn6bDdXSX6YsZ0r42dO3Fa0FVYzrlcVAuNB67e2b6w==",
-      "dev": true,
       "optional": true
     },
     "@mongodb-js/zstd-linux-arm64-gnu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-gnu/-/zstd-linux-arm64-gnu-1.2.0.tgz",
       "integrity": "sha512-TYF0XgNJW6UrvtY2u4Uuo5HiVWNgWNZ/ae2BhVp8hNsDhwFqb/YNoyiZqBei6whUwr8hecMy0UaHAXm3h+O2+Q==",
-      "dev": true,
       "optional": true
     },
     "@mongodb-js/zstd-linux-arm64-musl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-arm64-musl/-/zstd-linux-arm64-musl-1.2.0.tgz",
       "integrity": "sha512-e2ClmJI1BvJq23VSLH14hgjjjcMOad3R/Ap7Q7dTa1uiVSJG4xKd2CmrWQgX1Az4/EfUMWEI7pb4yuanbdd2AQ==",
-      "dev": true,
       "optional": true
     },
     "@mongodb-js/zstd-linux-x64-gnu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-gnu/-/zstd-linux-x64-gnu-1.2.0.tgz",
       "integrity": "sha512-JuoK8lxUlkFPDBfsBUJKnLxpXA5ar+v7G43lIUlBKgjOp5aEWO/qQp5sNgCRnYA7x6PItYqIkEJjsays4N6JOA==",
-      "dev": true,
       "optional": true
     },
     "@mongodb-js/zstd-linux-x64-musl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-linux-x64-musl/-/zstd-linux-x64-musl-1.2.0.tgz",
       "integrity": "sha512-pSb1iUF3Gc/qrJuP/Mi5ry4YFAUdUVFKNRZh1KTDDhSWyRCLd9gKcNdRnXqJjIdeGGEKf4bhtZAbYw4i/g0foA==",
-      "dev": true,
       "optional": true
     },
     "@mongodb-js/zstd-win32-x64-msvc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/zstd-win32-x64-msvc/-/zstd-win32-x64-msvc-1.2.0.tgz",
       "integrity": "sha512-iz4Yl+WK3yr/4Yg6F4tKz3X9+yMZDK6pyBMA0CdXydSDZs6o2XQ2I0ZSu3oSk/ACfaZX3SNfRi3XTGgAM1eKZA==",
-      "dev": true,
       "optional": true
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@gomomento/sdk": "^1.77.0",
+    "@mongodb-js/zstd": "^1.2.0",
     "ioredis": "5.3.2"
   },
   "devDependencies": {
-    "@gomomento/sdk-nodejs-compression": "^0.75.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
     "@types/uuid": "^9.0.1",
@@ -43,6 +43,9 @@
     "ts-jest": "^29.0.5",
     "typescript": "5.0.4",
     "uuid": "^9.0.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   },
   "eslintConfig": {
     "root": true,

--- a/src/wrap-ioredis.ts
+++ b/src/wrap-ioredis.ts
@@ -13,7 +13,7 @@ interface config {
   cacheName: string;
 }
 
-const authTokenEnvVarName = 'MOMENTO_AUTH_TOKEN';
+const authTokenEnvVarName = 'MOMENTO_API_KEY';
 
 function parseConfig(): config {
   const enableMomentoVar = process.env['MOMENTO_ENABLED'],

--- a/test/integration-setup.ts
+++ b/test/integration-setup.ts
@@ -8,9 +8,7 @@ import {
   CacheClient,
   CredentialProvider,
   CacheConfiguration,
-  Configuration,
 } from '@gomomento/sdk';
-import {CompressorFactory} from '@gomomento/sdk-nodejs-compression';
 import {MomentoIORedis, MomentoRedisAdapter, NewIORedisWrapper} from '../src';
 
 export function testCacheName(): string {
@@ -32,17 +30,11 @@ const deleteCacheIfExists = async (momento: CacheClient, cacheName: string) => {
 };
 
 function momentoClientForTesting() {
-  let configuration: CacheConfiguration | Configuration =
-    Configurations.Laptop.latest();
-  if (useCompression()) {
-    configuration = configuration.withCompressionStrategy({
-      compressorFactory: CompressorFactory.default(),
-    });
-  }
+  const configuration: CacheConfiguration = Configurations.Laptop.latest();
   const IntegrationTestCacheClientProps: CacheClientProps = {
     configuration,
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
-      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+      environmentVariableName: 'MOMENTO_API_KEY',
     }),
     defaultTtlSeconds: 60,
   };
@@ -88,7 +80,10 @@ function setupIntegrationTestWithMomento() {
   const momentoClient = momentoClientForTesting();
   const momentoNodeRedisClient = new MomentoRedisAdapter(
     momentoClient,
-    cacheName
+    cacheName,
+    {
+      useCompression: useCompression(),
+    }
   );
 
   return {client: momentoNodeRedisClient};


### PR DESCRIPTION
This commit modifies the code to use zstd directly for compression, rather than relying on the Momento SDK implementation. The primary motivation here is that the Momento SDK compression operations for dictionary APIs isn't stable yet, and this library really doesn't need to rely on the SDK implementation anyway.