### PR TITLE
feat: make the environment variable names for the wrappers more consistent

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -81,12 +81,12 @@ const redisClusterClient = NewIORedisClusterWrapper([], {});
 
 In this package we provide wrapper functions that help you configure wether or not to use Momento and how client settings should look based off environment variables. This is to try and make for a simpler drop in experience where you might be running Momento or Redis based off the environment or Region. This applies for `NewIORedisWrapper` and `NewIORedisClusterWrapper` wrapper functions.
 
-| EnvVar Name         | Description                                                | Default |
-|---------------------|------------------------------------------------------------|---------|
-| MOMENTO_ENABLED     | Will allow you to toggle between using Momento and IORedis | false   |
-| MOMENTO_API_KEY  | The Momento Auth token you would like to use               | ""      |
-| CACHE_NAME          | The name of the Momento Cache to use if Momento is enabled | ""      |
-| DEFAULT_TTL_SECONDS | The number of seconds to cache items for by default        | 86400   |
+| EnvVar Name                 | Description                                                | Default |
+|-----------------------------|------------------------------------------------------------|---------|
+| MOMENTO_ENABLED             | Will allow you to toggle between using Momento and IORedis | false   |
+| MOMENTO_API_KEY             | The Momento Auth token you would like to use               | ""      |
+| MOMENTO_CACHE_NAME          | The name of the Momento Cache to use if Momento is enabled | ""      |
+| MOMENTO_DEFAULT_TTL_SECONDS | The number of seconds to cache items for by default        | 86400   |
 
 ## Installation
 

--- a/src/wrap-ioredis.ts
+++ b/src/wrap-ioredis.ts
@@ -13,12 +13,15 @@ interface config {
   cacheName: string;
 }
 
-const authTokenEnvVarName = 'MOMENTO_API_KEY';
+const momentoApiKeyEnvVarName = 'MOMENTO_API_KEY';
+const momentoEnabledEnvVarName = 'MOMENTO_ENABLED';
+const momentoCacheNameEnvVarName = 'MOMENTO_CACHE_NAME';
+const momentoDefaultTtlEnvVarName = 'MOMENTO_DEFAULT_TTL_SECONDS';
 
 function parseConfig(): config {
-  const enableMomentoVar = process.env['MOMENTO_ENABLED'],
-    defaultTTLSecondsVar = process.env['DEFAULT_TTL_SECONDS'],
-    cacheNameVar = process.env['CACHE_NAME'];
+  const enableMomentoVar = process.env[momentoEnabledEnvVarName],
+    defaultTTLSecondsVar = process.env[momentoDefaultTtlEnvVarName],
+    cacheNameVar = process.env[momentoCacheNameEnvVarName];
   let enableMomento = false,
     defaultTTLSeconds = 86400,
     cacheName = '';
@@ -26,12 +29,16 @@ function parseConfig(): config {
   if (enableMomentoVar !== undefined && enableMomentoVar === 'true') {
     enableMomento = true;
     if (defaultTTLSecondsVar === undefined) {
-      throw new Error('missing DEFAULT_TTL env var when using momento');
+      throw new Error(
+        `missing ${momentoDefaultTtlEnvVarName} env var when using momento`
+      );
     } else {
       defaultTTLSeconds = Number.parseInt(defaultTTLSecondsVar);
     }
     if (cacheNameVar === undefined || cacheNameVar === '') {
-      throw new Error('missing CACHE_NAME env var when using momento');
+      throw new Error(
+        `missing ${momentoCacheNameEnvVarName} env var when using momento`
+      );
     } else {
       cacheName = cacheNameVar;
     }
@@ -49,9 +56,9 @@ export function NewIORedisWrapper(options?: RedisOptions): MomentoIORedis {
     return new MomentoRedisAdapter(
       new CacheClient({
         configuration: Configurations.Laptop.v1(),
-        credentialProvider: CredentialProvider.fromEnvironmentVariable({
-          environmentVariableName: authTokenEnvVarName,
-        }),
+        credentialProvider: CredentialProvider.fromEnvironmentVariable(
+          momentoApiKeyEnvVarName
+        ),
         defaultTtlSeconds: config.defaultTTLSeconds,
       }),
       config.cacheName
@@ -74,9 +81,9 @@ export function NewIORedisClusterWrapper(
     return new MomentoRedisAdapter(
       new CacheClient({
         configuration: Configurations.Laptop.v1(),
-        credentialProvider: CredentialProvider.fromEnvironmentVariable({
-          environmentVariableName: authTokenEnvVarName,
-        }),
+        credentialProvider: CredentialProvider.fromEnvironmentVariable(
+          momentoApiKeyEnvVarName
+        ),
         defaultTtlSeconds: config.defaultTTLSeconds,
       }),
       config.cacheName


### PR DESCRIPTION
This is a minor cleanup that makes the environment variable names
and code a little more consistent when using the "wrapper" factory
fns to create your redis client.
